### PR TITLE
augment default elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,33 +7,60 @@ A hypermedia extension for the browser.
 Augment the default `<a>` and `<form>` elements to create rich hypermedia experiences in the browser.
 
 ```html
-<a hx href="/some/url" target="selector" placement="replace">
+<a href="/some/url" target="selector" hx-placement="replace">
     click me!
 </a>
 
-<form hx action="/some/form/url" method="post" target="selector" placement="before">
+<form action="/some/form/url" method="post" target="selector" hx-placement="before">
     <input type="submit">
 </form>
 ```
 
-Add the `hx` attribute to any `<anchor>` or `<form>` element.
+Add the `hx-placement` attribute to `<a>` or `<form>` element.
 
+This changes the behavior of the `<anchor>` or `<form>` elements.
+
+`Hx` uses the `target` property to query an `element`.
+
+```
 target
-    selector: any css selector
-    _self
-    _parent
-    _top
+    _self -> the anchor or form element
+    _parent -> the parent element
+    _root -> the document or shadow root or "event root"
+    selector -> any css selector
+```
 
-placement
-    start
-    end
-    before
-    after
-    first-child
-    last-child
-    remove
-    replace
+Then `hx` uses the `hx-placement` property to define a placement strategy for the response in relation to the `target`.
+
+```
+hx-placement
+    before -> before selected element
+    after -> after selected element
+    start -> before descendants
+    end -> after descendants
+    remove -> remove regardless
+    replace -> replace element
+    none -> nothing will happen
+```
+
+## What about styles and scripts and ???
+
+Nope.
+
+This is it. Simply augmenting default elements for hypermedia experiences.
+
+There is an escape hatch with webcomponents.
+
+A response header `hx-resources` contains a list or urls (or none). This will trigger an asyncronous fetch of any external resources like web components, styles, etc.
+
+```
+hx-resources: "uwu.com/components/button.js;..."
+```
 
 ## bring your own middleware
 
 Create your own hypermedia responses 
+
+## License
+
+`Hx` is released under the BSD 3-Clause License

--- a/README.md
+++ b/README.md
@@ -2,54 +2,46 @@
 
 A hypermedia extension for the browser.
 
-## semantics
+## hx-core
 
 Augment the default `<a>` and `<form>` elements to create rich hypermedia experiences in the browser.
 
 ```html
-<a href="/some/url" target="selector" hx-placement="replace">
+<a href="/some/url" target="selector" hx-placement="before">
     click me!
 </a>
 
-<form action="/some/form/url" method="post" target="selector" hx-placement="before">
+<form action="/some/form/url" method="post" target="selector" hx-placement="replace">
     <input type="submit">
 </form>
 ```
 
-Add the `hx-placement` attribute to `<a>` or `<form>` element.
+Add the `hx-placement` attribute to `<a>` or `<form>` element to send an `hx-anchor` or `hx-form` event.
 
-This changes the behavior of the `<anchor>` or `<form>` elements.
+## hx-callbacks
 
 `Hx` uses the `target` property to query an `element`.
 
 ```
-target
+target -> event language?
     _self -> the anchor or form element
-    _parent -> the parent element
-    _root -> the document or shadow root or "event root"
-    selector -> any css selector
+    selector -> any css selector used on a document, shadow dom, or html element
 ```
 
 Then `hx` uses the `hx-placement` property to define a placement strategy for the response in relation to the `target`.
 
 ```
 hx-placement
+    none -> nothing will happen
     before -> before selected element
     after -> after selected element
     start -> before descendants
     end -> after descendants
     remove -> remove regardless
     replace -> replace element
-    none -> nothing will happen
 ```
 
-## What about styles and scripts and ???
-
-Nope.
-
-This is it. Simply augmenting default elements for hypermedia experiences.
-
-There is an escape hatch with webcomponents.
+## External resources
 
 A response header `hx-resources` contains a list or urls (or none). This will trigger an asyncronous fetch of any external resources like web components, styles, etc.
 
@@ -57,10 +49,6 @@ A response header `hx-resources` contains a list or urls (or none). This will tr
 hx-resources: "uwu.com/components/button.js;..."
 ```
 
-## bring your own middleware
-
-Create your own hypermedia responses 
-
 ## License
 
-`Hx` is released under the BSD 3-Clause License
+`Hx-js` is released under the BSD 3-Clause License

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# hx-js
+
+A hypermedia extension for the browser.
+
+## semantics
+
+Augment the default `<a>` and `<form>` elements to create rich hypermedia experiences in the browser.
+
+```html
+<a hx href="/some/url" target="selector" placement="replace">
+    click me!
+</a>
+
+<form hx action="/some/form/url" method="post" target="selector" placement="before">
+    <input type="submit">
+</form>
+```
+
+Add the `hx` attribute to any `<anchor>` or `<form>` element.
+
+target
+    selector: any css selector
+    _self
+    _parent
+    _top
+
+placement
+    start
+    end
+    before
+    after
+    first-child
+    last-child
+    remove
+    replace
+
+## bring your own middleware
+
+Create your own hypermedia responses 

--- a/hx-callbacks/README.md
+++ b/hx-callbacks/README.md
@@ -1,0 +1,25 @@
+target
+    _self -> the element itself
+    selector: any css selector
+
+hx-placement
+    none
+    start
+    end
+    before
+    after
+    remove
+    replace
+
+// stretch goals
+hx-headers
+hx-referrer
+hx-state=failed
+
+// if you can use attributes to send responses, you can use attributes to respond help css visualize responses
+
+// Browsers are hypermedia but they are inherintly linear by definition
+// -> get -> anchor -> get -> form -> anchor -> get
+
+// servers are inherently stateless but DOMAIN DATA is not
+// start simple, go for the same linear relationship as the browser

--- a/hx-callbacks/src/mod.ts
+++ b/hx-callbacks/src/mod.ts
@@ -1,0 +1,37 @@
+interface CallbacksImpl {
+    onAnchor(e: Event);
+    onSubmit(e: CustomEvent<HTMLElement | null>);
+}
+
+// might not be neccessary?
+class Callbacks implements CallbacksImpl {
+    constructor() {
+        this.onAnchor = this.onAnchor.bind(this);
+        this.onSubmit = this.onSubmit.bind(this);
+    }
+    onAnchor(e: Event) {}
+    onSubmit(e: CustomEvent<HTMLElement | null>) {}
+}
+
+class MessageQueue {
+    pushQueue: unknown[] = [];
+    popQueue: unknown[] = [];
+    currTask: unknown = {};
+
+    constructor() {
+        this.processRequest = this.processRequest.bind(this);
+    }
+
+    push(e: unknown) {
+        this.pushQueue.push(e);
+        // kickoff queue!
+        //
+        // pop push queue into popQueue
+        // pass request to 
+    }
+
+    async processRequest() {
+        // while pop push queue to pop queue
+        // pop off pop queue
+    }
+}

--- a/hx-core/src/mod.ts
+++ b/hx-core/src/mod.ts
@@ -5,38 +5,41 @@
 // should be included as an attribute
 // on the element making the hypermedia request.
 
-interface ElementWithEvents {
-    addEventListener: HTMLElement["addEventListener"];
-    removeEventListener: HTMLElement["removeEventListener"];
+interface CallbacksImpl {
+    requestHypermedia(
+        root: Node,
+        el: HTMLElement,
+    );
 }
 
-interface Callbacks {
-    requestHypermedia(root: HTMLElement, el: HTMLElement);
+interface HxCoreImpl {
+    connect(root: Node);
+    disconnect(root: Node);
 }
 
-class HxCore {
-    #callbacks: Callbacks;
+class HxCore implements HxCoreImpl {
+    #callbacks: CallbacksImpl;
 
-    constructor(callbacks: Callbacks) {
+    constructor(callbacks: CallbacksImpl) {
         this.#callbacks = callbacks;
         this.onAnchor = this.onAnchor.bind(this)
         this.onSubmit = this.onSubmit.bind(this);
     }
 
-    connect(root: ElementWithEvents) {
+    connect(root: Node) {
         root.addEventListener("pointerup", this.onAnchor);
         root.addEventListener("keydown", this.onAnchor);
         root.addEventListener("submit", this.onSubmit);
     }
 
-    disconnect(root: ElementWithEvents) {
+    disconnect(root: Node) {
         root.removeEventListener("pointerup", this.onAnchor);
         root.removeEventListener("keydown", this.onAnchor);
         root.removeEventListener("submit", this.onSubmit);
     }
 
     onAnchor(e: Event) {
-        if (!(e.currentTarget instanceof HTMLElement)) return;
+        if (!(e.currentTarget instanceof Node)) return;
         if (!(e.target instanceof HTMLElement)) return;
 
         let node: HTMLElement | null = e.target;
@@ -56,7 +59,7 @@ class HxCore {
 
     onSubmit(e: Event) {
         if (!(e instanceof SubmitEvent)) return;
-        if (!(e.currentTarget instanceof HTMLElement)) return;
+        if (!(e.currentTarget instanceof Node)) return;
         if (!(e.target instanceof HTMLFormElement)) return;
 
         const hx = e.target.getAttribute("hx");
@@ -67,6 +70,6 @@ class HxCore {
     }
 }
 
-export type { Callbacks, ElementWithEvents }
+export type { HxCoreImpl, CallbacksImpl }
 
 export { HxCore }

--- a/hx-core/src/mod.ts
+++ b/hx-core/src/mod.ts
@@ -1,23 +1,15 @@
-function connect(root: Node, callback: EventListenerOrEventListenerObject) {
-    root.addEventListener("pointerup", onAnchor);
-    root.addEventListener("keydown", onAnchor);
-    root.addEventListener("submit", onSubmit);
+class HxAnchorEvent extends Event {
+    constructor() {
+        super("hx-anchor", {composed: true, bubbles: true});
+    }
 }
 
-function disconnect(root: Node, callback: EventListenerOrEventListenerObject) {
-    root.removeEventListener("pointerup", onAnchor);
-    root.removeEventListener("keydown", onAnchor);
-    root.removeEventListener("submit", onSubmit);
-}
-
-function onSubmit(e: Event) {
-    if (!(e instanceof SubmitEvent && e.currentTarget instanceof Node && e.target instanceof HTMLFormElement)) return;
-
-    const hx = e.target.getAttribute("hx-placement");
-    if (!hx || hx !== "") return;
-
-    e.preventDefault();
-    e.currentTarget.dispatchEvent(new Event("hypermedia-request"));
+class HxFormEvent extends Event {
+    submitter;
+    constructor(submitter: HTMLElement | null) {
+        super("hx-form", {composed: true, bubbles: true});
+        this.submitter = submitter;
+    }
 }
 
 function onAnchor(e: Event) {
@@ -35,7 +27,17 @@ function onAnchor(e: Event) {
     if (!hx || hx !== "") return;
 
     e.preventDefault();
-    e.currentTarget.dispatchEvent(new Event("hypermedia-request"));
+    node.dispatchEvent(new HxAnchorEvent());
 }
 
-export { connect, disconnect }
+function onSubmit(e: Event) {
+    if (!(e instanceof SubmitEvent && e.target instanceof HTMLFormElement && e.currentTarget instanceof Node)) return;
+
+    const hx = e.target.getAttribute("hx-placement");
+    if (!hx || hx !== "") return;
+
+    e.preventDefault();
+    e.target.dispatchEvent(new HxFormEvent(e.submitter));
+}
+
+export { onAnchor, onSubmit, HxAnchorEvent, HxFormEvent }

--- a/hx-core/src/mod.ts
+++ b/hx-core/src/mod.ts
@@ -39,8 +39,7 @@ class HxCore implements HxCoreImpl {
     }
 
     onAnchor(e: Event) {
-        if (!(e.currentTarget instanceof Node)) return;
-        if (!(e.target instanceof HTMLElement)) return;
+        if (!(e.currentTarget instanceof Node && e.target instanceof HTMLElement)) return;
 
         let node: HTMLElement | null = e.target;
         while (node && node !== e.currentTarget) {
@@ -58,9 +57,7 @@ class HxCore implements HxCoreImpl {
     }
 
     onSubmit(e: Event) {
-        if (!(e instanceof SubmitEvent)) return;
-        if (!(e.currentTarget instanceof Node)) return;
-        if (!(e.target instanceof HTMLFormElement)) return;
+        if (!(e instanceof SubmitEvent && e.currentTarget instanceof Node && e.target instanceof HTMLElement)) return;
 
         const hx = e.target.getAttribute("hx");
         if (!hx || hx !== "") return;

--- a/hx-core/src/mod.ts
+++ b/hx-core/src/mod.ts
@@ -1,0 +1,72 @@
+// All request properties
+// All selector properties
+// All placement properties
+//
+// should be included as an attribute
+// on the element making the hypermedia request.
+
+interface ElementWithEvents {
+    addEventListener: HTMLElement["addEventListener"];
+    removeEventListener: HTMLElement["removeEventListener"];
+}
+
+interface Callbacks {
+    requestHypermedia(root: HTMLElement, el: HTMLElement);
+}
+
+class HxCore {
+    #callbacks: Callbacks;
+
+    constructor(callbacks: Callbacks) {
+        this.#callbacks = callbacks;
+        this.onAnchor = this.onAnchor.bind(this)
+        this.onSubmit = this.onSubmit.bind(this);
+    }
+
+    connect(root: ElementWithEvents) {
+        root.addEventListener("pointerup", this.onAnchor);
+        root.addEventListener("keydown", this.onAnchor);
+        root.addEventListener("submit", this.onSubmit);
+    }
+
+    disconnect(root: ElementWithEvents) {
+        root.removeEventListener("pointerup", this.onAnchor);
+        root.removeEventListener("keydown", this.onAnchor);
+        root.removeEventListener("submit", this.onSubmit);
+    }
+
+    onAnchor(e: Event) {
+        if (!(e.currentTarget instanceof HTMLElement)) return;
+        if (!(e.target instanceof HTMLElement)) return;
+
+        let node: HTMLElement | null = e.target;
+        while (node && node !== e.currentTarget) {
+            if (node instanceof HTMLAnchorElement) break;
+            node = node.parentElement;
+        }
+
+        if (!(node instanceof HTMLAnchorElement)) return;
+
+        const hx = node.getAttribute("hx");
+        if (!hx || hx !== "") return
+
+        e.preventDefault();
+        this.#callbacks.requestHypermedia(e.currentTarget, e.target);
+    }
+
+    onSubmit(e: Event) {
+        if (!(e instanceof SubmitEvent)) return;
+        if (!(e.currentTarget instanceof HTMLElement)) return;
+        if (!(e.target instanceof HTMLFormElement)) return;
+
+        const hx = e.target.getAttribute("hx");
+        if (!hx || hx !== "") return;
+
+        e.preventDefault();
+        this.#callbacks.requestHypermedia(e.currentTarget, e.target);
+    }
+}
+
+export type { Callbacks, ElementWithEvents }
+
+export { HxCore }

--- a/hx-core/src/mod.ts
+++ b/hx-core/src/mod.ts
@@ -1,72 +1,41 @@
-// All request properties
-// All selector properties
-// All placement properties
-//
-// should be included as an attribute
-// on the element making the hypermedia request.
-
-interface CallbacksImpl {
-    requestHypermedia(
-        root: Node,
-        el: HTMLElement,
-    );
+function connect(root: Node, callback: EventListenerOrEventListenerObject) {
+    root.addEventListener("pointerup", onAnchor);
+    root.addEventListener("keydown", onAnchor);
+    root.addEventListener("submit", onSubmit);
 }
 
-interface HxCoreImpl {
-    connect(root: Node);
-    disconnect(root: Node);
+function disconnect(root: Node, callback: EventListenerOrEventListenerObject) {
+    root.removeEventListener("pointerup", onAnchor);
+    root.removeEventListener("keydown", onAnchor);
+    root.removeEventListener("submit", onSubmit);
 }
 
-class HxCore implements HxCoreImpl {
-    #callbacks: CallbacksImpl;
+function onSubmit(e: Event) {
+    if (!(e instanceof SubmitEvent && e.currentTarget instanceof Node && e.target instanceof HTMLFormElement)) return;
 
-    constructor(callbacks: CallbacksImpl) {
-        this.#callbacks = callbacks;
-        this.onAnchor = this.onAnchor.bind(this)
-        this.onSubmit = this.onSubmit.bind(this);
-    }
+    const hx = e.target.getAttribute("hx-placement");
+    if (!hx || hx !== "") return;
 
-    connect(root: Node) {
-        root.addEventListener("pointerup", this.onAnchor);
-        root.addEventListener("keydown", this.onAnchor);
-        root.addEventListener("submit", this.onSubmit);
-    }
-
-    disconnect(root: Node) {
-        root.removeEventListener("pointerup", this.onAnchor);
-        root.removeEventListener("keydown", this.onAnchor);
-        root.removeEventListener("submit", this.onSubmit);
-    }
-
-    onAnchor(e: Event) {
-        if (!(e.currentTarget instanceof Node && e.target instanceof HTMLElement)) return;
-
-        let node: HTMLElement | null = e.target;
-        while (node && node !== e.currentTarget) {
-            if (node instanceof HTMLAnchorElement) break;
-            node = node.parentElement;
-        }
-
-        if (!(node instanceof HTMLAnchorElement)) return;
-
-        const hx = node.getAttribute("hx");
-        if (!hx || hx !== "") return
-
-        e.preventDefault();
-        this.#callbacks.requestHypermedia(e.currentTarget, e.target);
-    }
-
-    onSubmit(e: Event) {
-        if (!(e instanceof SubmitEvent && e.currentTarget instanceof Node && e.target instanceof HTMLElement)) return;
-
-        const hx = e.target.getAttribute("hx");
-        if (!hx || hx !== "") return;
-
-        e.preventDefault();
-        this.#callbacks.requestHypermedia(e.currentTarget, e.target);
-    }
+    e.preventDefault();
+    e.currentTarget.dispatchEvent(new Event("hypermedia-request"));
 }
 
-export type { HxCoreImpl, CallbacksImpl }
+function onAnchor(e: Event) {
+    if (!(e.currentTarget instanceof Node && e.target instanceof HTMLElement)) return;
 
-export { HxCore }
+    let node: HTMLElement | null = e.target;
+    while (node && node !== e.currentTarget) {
+        if (node instanceof HTMLAnchorElement) break;
+        node = node.parentElement;
+    }
+
+    if (!(node instanceof HTMLAnchorElement)) return;
+
+    const hx = node.getAttribute("hx-placement");
+    if (!hx || hx !== "") return;
+
+    e.preventDefault();
+    e.currentTarget.dispatchEvent(new Event("hypermedia-request"));
+}
+
+export { connect, disconnect }

--- a/hx/src/mod.ts
+++ b/hx/src/mod.ts
@@ -1,7 +1,3 @@
 // this is where an opinionated stance happens
 
-// hx-callbacks with an event queue
-
-// added to hx-core
-
-// exported
+// combine hx-core with callbacks here

--- a/hx/src/mod.ts
+++ b/hx/src/mod.ts
@@ -1,0 +1,7 @@
+// this is where an opinionated stance happens
+
+// hx-callbacks with an event queue
+
+// added to hx-core
+
+// exported

--- a/hx/src/mod.ts
+++ b/hx/src/mod.ts
@@ -1,3 +1,0 @@
-// this is where an opinionated stance happens
-
-// combine hx-core with callbacks here


### PR DESCRIPTION
augment default anchor and form elements.

when the `hx-placement` property is present on an `a` or `form` element, an `anchor` tag will dispatch an `hx-anchor` event and the form will dispatch a `hx-form` event.